### PR TITLE
apply onPreHandler only for JsonRPC route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ export const plugin = {
 		}
 
 		server.ext("onPreHandler", (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+			if (request.path !== "/" || request.method !== "post") {
+				return h.continue;
+			}
+
 			if (request.headers["content-type"]) {
 				const contentMedia: Record<string, any> = MediaType.fromString(request.headers["content-type"]);
 


### PR DESCRIPTION
OnPreHandler is only applied to jsonRPC route (method: post, route: /). Other routes will not be affected by validation logic. 